### PR TITLE
Update generate.py

### DIFF
--- a/simStubsGen/generate.py
+++ b/simStubsGen/generate.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import os
 import os.path


### PR DESCRIPTION
FIX: problems compiling due to problems between Python 2.x and 3.x with the 'print' function
*Problem appeared trying to compile the ros_interface plugin for CoppeliaSim